### PR TITLE
Replace log with logrus

### DIFF
--- a/flexibleengine/auth_helpers.go
+++ b/flexibleengine/auth_helpers.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"strings"
 	"time"

--- a/flexibleengine/compute_bms_v2_server_addresses.go
+++ b/flexibleengine/compute_bms_v2_server_addresses.go
@@ -11,7 +11,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/huaweicloud/golangsdk/openstack/compute/v2/servers"

--- a/flexibleengine/compute_instance_v2_networking.go
+++ b/flexibleengine/compute_instance_v2_networking.go
@@ -11,7 +11,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/flexibleengine/compute_interface_attach_v2.go
+++ b/flexibleengine/compute_interface_attach_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/huaweicloud/golangsdk"

--- a/flexibleengine/config.go
+++ b/flexibleengine/config.go
@@ -4,7 +4,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"strings"
 

--- a/flexibleengine/data_source_flexibleengine_blockstorage_volume_v2.go
+++ b/flexibleengine/data_source_flexibleengine_blockstorage_volume_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 

--- a/flexibleengine/data_source_flexibleengine_cce_cluster_v3.go
+++ b/flexibleengine/data_source_flexibleengine_cce_cluster_v3.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/huaweicloud/golangsdk/openstack/cce/v3/clusters"

--- a/flexibleengine/data_source_flexibleengine_cce_node_v3.go
+++ b/flexibleengine/data_source_flexibleengine_cce_node_v3.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/huaweicloud/golangsdk/openstack/cce/v3/nodes"

--- a/flexibleengine/data_source_flexibleengine_compute_bms_flavor_v2.go
+++ b/flexibleengine/data_source_flexibleengine_compute_bms_flavor_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/huaweicloud/golangsdk/openstack/bms/v2/flavors"

--- a/flexibleengine/data_source_flexibleengine_compute_bms_keypair_v2.go
+++ b/flexibleengine/data_source_flexibleengine_compute_bms_keypair_v2.go
@@ -3,7 +3,7 @@ package flexibleengine
 import (
 	"fmt"
 
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/huaweicloud/golangsdk/openstack/bms/v2/keypairs"

--- a/flexibleengine/data_source_flexibleengine_compute_bms_nic_v2.go
+++ b/flexibleengine/data_source_flexibleengine_compute_bms_nic_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/huaweicloud/golangsdk/openstack/bms/v2/nics"

--- a/flexibleengine/data_source_flexibleengine_compute_bms_server_v2.go
+++ b/flexibleengine/data_source_flexibleengine_compute_bms_server_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/huaweicloud/golangsdk/openstack/bms/v2/servers"

--- a/flexibleengine/data_source_flexibleengine_csbs_backup_policy_v1.go
+++ b/flexibleengine/data_source_flexibleengine_csbs_backup_policy_v1.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/huaweicloud/golangsdk/openstack/csbs/v1/policies"

--- a/flexibleengine/data_source_flexibleengine_csbs_backup_v1.go
+++ b/flexibleengine/data_source_flexibleengine_csbs_backup_v1.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/huaweicloud/golangsdk/openstack/csbs/v1/backup"

--- a/flexibleengine/data_source_flexibleengine_cts_tracker_v1.go
+++ b/flexibleengine/data_source_flexibleengine_cts_tracker_v1.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/huaweicloud/golangsdk/openstack/cts/v1/tracker"

--- a/flexibleengine/data_source_flexibleengine_dcs_az_v1.go
+++ b/flexibleengine/data_source_flexibleengine_dcs_az_v1.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/huaweicloud/golangsdk/openstack/dcs/v1/availablezones"

--- a/flexibleengine/data_source_flexibleengine_dcs_maintainwindow_v1.go
+++ b/flexibleengine/data_source_flexibleengine_dcs_maintainwindow_v1.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/flexibleengine/data_source_flexibleengine_dcs_product_v1.go
+++ b/flexibleengine/data_source_flexibleengine_dcs_product_v1.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/huaweicloud/golangsdk/openstack/dcs/v1/products"

--- a/flexibleengine/data_source_flexibleengine_dds_flavors_v3.go
+++ b/flexibleengine/data_source_flexibleengine_dds_flavors_v3.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 

--- a/flexibleengine/data_source_flexibleengine_dns_zone_v2.go
+++ b/flexibleengine/data_source_flexibleengine_dns_zone_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/huaweicloud/golangsdk/openstack/dns/v2/zones"

--- a/flexibleengine/data_source_flexibleengine_identity_project_v3.go
+++ b/flexibleengine/data_source_flexibleengine_identity_project_v3.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/huaweicloud/golangsdk/openstack/identity/v3/projects"

--- a/flexibleengine/data_source_flexibleengine_identity_role_v3.go
+++ b/flexibleengine/data_source_flexibleengine_identity_role_v3.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/huaweicloud/golangsdk/openstack/identity/v3/roles"

--- a/flexibleengine/data_source_flexibleengine_images_image_v2.go
+++ b/flexibleengine/data_source_flexibleengine_images_image_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sort"
 
 	"github.com/huaweicloud/golangsdk/openstack/imageservice/v2/images"

--- a/flexibleengine/data_source_flexibleengine_kms_data_key_v1.go
+++ b/flexibleengine/data_source_flexibleengine_kms_data_key_v1.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/flexibleengine/data_source_flexibleengine_kms_key_v1.go
+++ b/flexibleengine/data_source_flexibleengine_kms_key_v1.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/flexibleengine/data_source_flexibleengine_networking_network_v2.go
+++ b/flexibleengine/data_source_flexibleengine_networking_network_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/flexibleengine/data_source_flexibleengine_networking_secgroup_v2.go
+++ b/flexibleengine/data_source_flexibleengine_networking_secgroup_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/security/groups"
 

--- a/flexibleengine/data_source_flexibleengine_rds_flavors_v1.go
+++ b/flexibleengine/data_source_flexibleengine_rds_flavors_v1.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 

--- a/flexibleengine/data_source_flexibleengine_rts_software_config_v1.go
+++ b/flexibleengine/data_source_flexibleengine_rts_software_config_v1.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/huaweicloud/golangsdk/openstack/rts/v1/softwareconfig"

--- a/flexibleengine/data_source_flexibleengine_rts_stack_v1.go
+++ b/flexibleengine/data_source_flexibleengine_rts_stack_v1.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/flexibleengine/data_source_flexibleengine_s3_bucket_object.go
+++ b/flexibleengine/data_source_flexibleengine_s3_bucket_object.go
@@ -3,7 +3,7 @@ package flexibleengine
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"strings"
 	"time"

--- a/flexibleengine/data_source_flexibleengine_sdrs_domain_v1.go
+++ b/flexibleengine/data_source_flexibleengine_sdrs_domain_v1.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/huaweicloud/golangsdk/openstack/sdrs/v1/domains"

--- a/flexibleengine/data_source_flexibleengine_sfs_file_system_v2.go
+++ b/flexibleengine/data_source_flexibleengine_sfs_file_system_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/huaweicloud/golangsdk/openstack/sfs/v2/shares"
 

--- a/flexibleengine/data_source_flexibleengine_vbs_backup_policy_v2.go
+++ b/flexibleengine/data_source_flexibleengine_vbs_backup_policy_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/huaweicloud/golangsdk/openstack/vbs/v2/policies"

--- a/flexibleengine/data_source_flexibleengine_vbs_backup_v2.go
+++ b/flexibleengine/data_source_flexibleengine_vbs_backup_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/huaweicloud/golangsdk/openstack/vbs/v2/backups"

--- a/flexibleengine/data_source_flexibleengine_vpc_peering_connection_v2.go
+++ b/flexibleengine/data_source_flexibleengine_vpc_peering_connection_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/huaweicloud/golangsdk/openstack/networking/v2/peerings"
 

--- a/flexibleengine/data_source_flexibleengine_vpc_route_v2_.go
+++ b/flexibleengine/data_source_flexibleengine_vpc_route_v2_.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/huaweicloud/golangsdk/openstack/networking/v2/routes"
 
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )

--- a/flexibleengine/data_source_flexibleengine_vpc_subnet_v1.go
+++ b/flexibleengine/data_source_flexibleengine_vpc_subnet_v1.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/huaweicloud/golangsdk/openstack/networking/v1/subnets"
 

--- a/flexibleengine/data_source_flexibleengine_vpc_v1.go
+++ b/flexibleengine/data_source_flexibleengine_vpc_v1.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/huaweicloud/golangsdk/openstack/networking/v1/vpcs"
 

--- a/flexibleengine/diff_suppress_funcs.go
+++ b/flexibleengine/diff_suppress_funcs.go
@@ -3,7 +3,7 @@ package flexibleengine
 import (
 	"bytes"
 	"encoding/json"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/url"
 	"reflect"
 	"sort"

--- a/flexibleengine/elb_utils.go
+++ b/flexibleengine/elb_utils.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/flexibleengine/lb_v2_shared.go
+++ b/flexibleengine/lb_v2_shared.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/flexibleengine/resource_flexibleengine_antiddos_v1.go
+++ b/flexibleengine/resource_flexibleengine_antiddos_v1.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/flexibleengine/resource_flexibleengine_as_configuration_v1.go
+++ b/flexibleengine/resource_flexibleengine_as_configuration_v1.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"crypto/sha1"
 	"encoding/hex"

--- a/flexibleengine/resource_flexibleengine_as_configuration_v1_test.go
+++ b/flexibleengine/resource_flexibleengine_as_configuration_v1_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 
 	"github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/configurations"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 )
 
 func TestAccASV1Configuration_basic(t *testing.T) {

--- a/flexibleengine/resource_flexibleengine_as_group_v1.go
+++ b/flexibleengine/resource_flexibleengine_as_group_v1.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/flexibleengine/resource_flexibleengine_as_group_v1_test.go
+++ b/flexibleengine/resource_flexibleengine_as_group_v1_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 
 	"github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/groups"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 )
 
 func TestAccASV1Group_basic(t *testing.T) {

--- a/flexibleengine/resource_flexibleengine_as_policy_v1.go
+++ b/flexibleengine/resource_flexibleengine_as_policy_v1.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/policies"

--- a/flexibleengine/resource_flexibleengine_as_policy_v1_test.go
+++ b/flexibleengine/resource_flexibleengine_as_policy_v1_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 
 	"github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/policies"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 )
 
 func TestAccASV1Policy_basic(t *testing.T) {

--- a/flexibleengine/resource_flexibleengine_blockstorage_volume_v2.go
+++ b/flexibleengine/resource_flexibleengine_blockstorage_volume_v2.go
@@ -3,7 +3,7 @@ package flexibleengine
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"

--- a/flexibleengine/resource_flexibleengine_cce_cluster_v3.go
+++ b/flexibleengine/resource_flexibleengine_cce_cluster_v3.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/flexibleengine/resource_flexibleengine_cce_node_v3.go
+++ b/flexibleengine/resource_flexibleengine_cce_node_v3.go
@@ -5,7 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"time"
 

--- a/flexibleengine/resource_flexibleengine_ces_alarmrule.go
+++ b/flexibleengine/resource_flexibleengine_ces_alarmrule.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/flexibleengine/resource_flexibleengine_compute_bms_server_v2.go
+++ b/flexibleengine/resource_flexibleengine_compute_bms_server_v2.go
@@ -4,7 +4,7 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"time"
 

--- a/flexibleengine/resource_flexibleengine_compute_floatingip_associate_v2.go
+++ b/flexibleengine/resource_flexibleengine_compute_floatingip_associate_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/flexibleengine/resource_flexibleengine_compute_floatingip_v2.go
+++ b/flexibleengine/resource_flexibleengine_compute_floatingip_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"time"
 

--- a/flexibleengine/resource_flexibleengine_compute_instance_v2.go
+++ b/flexibleengine/resource_flexibleengine_compute_instance_v2.go
@@ -5,7 +5,7 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"time"
 

--- a/flexibleengine/resource_flexibleengine_compute_interface_attach_v2.go
+++ b/flexibleengine/resource_flexibleengine_compute_interface_attach_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/huaweicloud/golangsdk/openstack/compute/v2/extensions/attachinterfaces"

--- a/flexibleengine/resource_flexibleengine_compute_keypair_v2.go
+++ b/flexibleengine/resource_flexibleengine_compute_keypair_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/huaweicloud/golangsdk/openstack/compute/v2/extensions/keypairs"

--- a/flexibleengine/resource_flexibleengine_compute_servergroup_v2.go
+++ b/flexibleengine/resource_flexibleengine_compute_servergroup_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/huaweicloud/golangsdk/openstack/compute/v2/extensions/servergroups"

--- a/flexibleengine/resource_flexibleengine_compute_volume_attach_v2.go
+++ b/flexibleengine/resource_flexibleengine_compute_volume_attach_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"time"
 

--- a/flexibleengine/resource_flexibleengine_csbs_backup_policy_v1.go
+++ b/flexibleengine/resource_flexibleengine_csbs_backup_policy_v1.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/flexibleengine/resource_flexibleengine_csbs_backup_v1.go
+++ b/flexibleengine/resource_flexibleengine_csbs_backup_v1.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/flexibleengine/resource_flexibleengine_css_cluster_v1.go
+++ b/flexibleengine/resource_flexibleengine_css_cluster_v1.go
@@ -16,7 +16,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"time"
 

--- a/flexibleengine/resource_flexibleengine_css_snapshot_v1.go
+++ b/flexibleengine/resource_flexibleengine_css_snapshot_v1.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"time"
 

--- a/flexibleengine/resource_flexibleengine_cts_tracker_v1.go
+++ b/flexibleengine/resource_flexibleengine_cts_tracker_v1.go
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/huaweicloud/golangsdk"

--- a/flexibleengine/resource_flexibleengine_dcs_instance_v1.go
+++ b/flexibleengine/resource_flexibleengine_dcs_instance_v1.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/flexibleengine/resource_flexibleengine_dds_instance_v3.go
+++ b/flexibleengine/resource_flexibleengine_dds_instance_v3.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"time"
 

--- a/flexibleengine/resource_flexibleengine_dns_recordset_v2.go
+++ b/flexibleengine/resource_flexibleengine_dns_recordset_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"time"
 

--- a/flexibleengine/resource_flexibleengine_dns_zone_v2.go
+++ b/flexibleengine/resource_flexibleengine_dns_zone_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/huaweicloud/golangsdk"

--- a/flexibleengine/resource_flexibleengine_drs_replication_v2.go
+++ b/flexibleengine/resource_flexibleengine_drs_replication_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"time"
 

--- a/flexibleengine/resource_flexibleengine_drs_replication_v2_test.go
+++ b/flexibleengine/resource_flexibleengine_drs_replication_v2_test.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/flexibleengine/resource_flexibleengine_drs_replicationconsistencygroup_v2.go
+++ b/flexibleengine/resource_flexibleengine_drs_replicationconsistencygroup_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/flexibleengine/resource_flexibleengine_drs_replicationconsistencygroup_v2_test.go
+++ b/flexibleengine/resource_flexibleengine_drs_replicationconsistencygroup_v2_test.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/flexibleengine/resource_flexibleengine_dws_cluster_v1.go
+++ b/flexibleengine/resource_flexibleengine_dws_cluster_v1.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/flexibleengine/resource_flexibleengine_ecs_v1_util.go
+++ b/flexibleengine/resource_flexibleengine_ecs_v1_util.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/flexibleengine/resource_flexibleengine_elb_backend.go
+++ b/flexibleengine/resource_flexibleengine_elb_backend.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/flexibleengine/resource_flexibleengine_elb_backend_test.go
+++ b/flexibleengine/resource_flexibleengine_elb_backend_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/elbaas/backendmember"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 )
 
 func TestAccELBBackend_basic(t *testing.T) {

--- a/flexibleengine/resource_flexibleengine_elb_health.go
+++ b/flexibleengine/resource_flexibleengine_elb_health.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/flexibleengine/resource_flexibleengine_elb_health_test.go
+++ b/flexibleengine/resource_flexibleengine_elb_health_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"

--- a/flexibleengine/resource_flexibleengine_elb_listener.go
+++ b/flexibleengine/resource_flexibleengine_elb_listener.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/flexibleengine/resource_flexibleengine_elb_loadbalancer.go
+++ b/flexibleengine/resource_flexibleengine_elb_loadbalancer.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/flexibleengine/resource_flexibleengine_elb_loadbalancer_test.go
+++ b/flexibleengine/resource_flexibleengine_elb_loadbalancer_test.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/flexibleengine/resource_flexibleengine_fw_firewall_group_v2.go
+++ b/flexibleengine/resource_flexibleengine_fw_firewall_group_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/flexibleengine/resource_flexibleengine_fw_policy_v2.go
+++ b/flexibleengine/resource_flexibleengine_fw_policy_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/flexibleengine/resource_flexibleengine_fw_rule_v2.go
+++ b/flexibleengine/resource_flexibleengine_fw_rule_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/huaweicloud/golangsdk"

--- a/flexibleengine/resource_flexibleengine_identity_agency_v3.go
+++ b/flexibleengine/resource_flexibleengine_identity_agency_v3.go
@@ -3,7 +3,7 @@ package flexibleengine
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"time"
 

--- a/flexibleengine/resource_flexibleengine_identity_group_v3.go
+++ b/flexibleengine/resource_flexibleengine_identity_group_v3.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/huaweicloud/golangsdk/openstack/identity/v3/groups"

--- a/flexibleengine/resource_flexibleengine_identity_role_assignment_v3.go
+++ b/flexibleengine/resource_flexibleengine_identity_role_assignment_v3.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/flexibleengine/resource_flexibleengine_identity_role_v3.go
+++ b/flexibleengine/resource_flexibleengine_identity_role_v3.go
@@ -16,7 +16,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"strings"
 

--- a/flexibleengine/resource_flexibleengine_identity_user_v3.go
+++ b/flexibleengine/resource_flexibleengine_identity_user_v3.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/huaweicloud/golangsdk/openstack/identity/v3/users"

--- a/flexibleengine/resource_flexibleengine_images_image_v2.go
+++ b/flexibleengine/resource_flexibleengine_images_image_v2.go
@@ -5,7 +5,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"os"
 	"path/filepath"

--- a/flexibleengine/resource_flexibleengine_kms_key_v1.go
+++ b/flexibleengine/resource_flexibleengine_kms_key_v1.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/flexibleengine/resource_flexibleengine_lb_certificate_v2.go
+++ b/flexibleengine/resource_flexibleengine_lb_certificate_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/flexibleengine/resource_flexibleengine_lb_l7policy_v2.go
+++ b/flexibleengine/resource_flexibleengine_lb_l7policy_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/flexibleengine/resource_flexibleengine_lb_l7rule_v2.go
+++ b/flexibleengine/resource_flexibleengine_lb_l7rule_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"time"
 

--- a/flexibleengine/resource_flexibleengine_lb_listener_v2.go
+++ b/flexibleengine/resource_flexibleengine_lb_listener_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/flexibleengine/resource_flexibleengine_lb_loadbalancer_v2.go
+++ b/flexibleengine/resource_flexibleengine_lb_loadbalancer_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/flexibleengine/resource_flexibleengine_lb_member_v2.go
+++ b/flexibleengine/resource_flexibleengine_lb_member_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/flexibleengine/resource_flexibleengine_lb_monitor_v2.go
+++ b/flexibleengine/resource_flexibleengine_lb_monitor_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/flexibleengine/resource_flexibleengine_lb_pool_v2.go
+++ b/flexibleengine/resource_flexibleengine_lb_pool_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/flexibleengine/resource_flexibleengine_lb_whitelist_v2.go
+++ b/flexibleengine/resource_flexibleengine_lb_whitelist_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/flexibleengine/resource_flexibleengine_mls_instance_v1.go
+++ b/flexibleengine/resource_flexibleengine_mls_instance_v1.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/flexibleengine/resource_flexibleengine_mrs_cluster_v1.go
+++ b/flexibleengine/resource_flexibleengine_mrs_cluster_v1.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 	"time"
 

--- a/flexibleengine/resource_flexibleengine_mrs_hybrid_cluster_v1.go
+++ b/flexibleengine/resource_flexibleengine_mrs_hybrid_cluster_v1.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 	"time"
 

--- a/flexibleengine/resource_flexibleengine_mrs_job_v1.go
+++ b/flexibleengine/resource_flexibleengine_mrs_job_v1.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/flexibleengine/resource_flexibleengine_nat_dnat_rule_v2.go
+++ b/flexibleengine/resource_flexibleengine_nat_dnat_rule_v2.go
@@ -16,7 +16,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/flexibleengine/resource_flexibleengine_nat_gateway_v2.go
+++ b/flexibleengine/resource_flexibleengine_nat_gateway_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/flexibleengine/resource_flexibleengine_nat_snat_rule_v2.go
+++ b/flexibleengine/resource_flexibleengine_nat_snat_rule_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/flexibleengine/resource_flexibleengine_networking_floatingip_associate_v2.go
+++ b/flexibleengine/resource_flexibleengine_networking_floatingip_associate_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 

--- a/flexibleengine/resource_flexibleengine_networking_floatingip_v2.go
+++ b/flexibleengine/resource_flexibleengine_networking_floatingip_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/flexibleengine/resource_flexibleengine_networking_network_v2.go
+++ b/flexibleengine/resource_flexibleengine_networking_network_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 	"time"
 

--- a/flexibleengine/resource_flexibleengine_networking_port_v2.go
+++ b/flexibleengine/resource_flexibleengine_networking_port_v2.go
@@ -3,7 +3,7 @@ package flexibleengine
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"

--- a/flexibleengine/resource_flexibleengine_networking_router_interface_v2.go
+++ b/flexibleengine/resource_flexibleengine_networking_router_interface_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/flexibleengine/resource_flexibleengine_networking_router_route_v2.go
+++ b/flexibleengine/resource_flexibleengine_networking_router_route_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 

--- a/flexibleengine/resource_flexibleengine_networking_router_v2.go
+++ b/flexibleengine/resource_flexibleengine_networking_router_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/flexibleengine/resource_flexibleengine_networking_secgroup_rule_v2.go
+++ b/flexibleengine/resource_flexibleengine_networking_secgroup_rule_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 	"strings"
 	"time"

--- a/flexibleengine/resource_flexibleengine_networking_secgroup_v2.go
+++ b/flexibleengine/resource_flexibleengine_networking_secgroup_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/flexibleengine/resource_flexibleengine_networking_subnet_v2.go
+++ b/flexibleengine/resource_flexibleengine_networking_subnet_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/flexibleengine/resource_flexibleengine_networking_vip_associate_v2.go
+++ b/flexibleengine/resource_flexibleengine_networking_vip_associate_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/flexibleengine/resource_flexibleengine_networking_vip_associate_v2_test.go
+++ b/flexibleengine/resource_flexibleengine_networking_vip_associate_v2_test.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/flexibleengine/resource_flexibleengine_networking_vip_v2.go
+++ b/flexibleengine/resource_flexibleengine_networking_vip_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/flexibleengine/resource_flexibleengine_networking_vip_v2_test.go
+++ b/flexibleengine/resource_flexibleengine_networking_vip_v2_test.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/flexibleengine/resource_flexibleengine_obs_bucket.go
+++ b/flexibleengine/resource_flexibleengine_obs_bucket.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/url"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/flexibleengine/resource_flexibleengine_obs_bucket_object.go
+++ b/flexibleengine/resource_flexibleengine_obs_bucket_object.go
@@ -3,7 +3,7 @@ package flexibleengine
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"strings"
 

--- a/flexibleengine/resource_flexibleengine_rds_configuration_v3.go
+++ b/flexibleengine/resource_flexibleengine_rds_configuration_v3.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"time"
 

--- a/flexibleengine/resource_flexibleengine_rds_instance_v1.go
+++ b/flexibleengine/resource_flexibleengine_rds_instance_v1.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/flexibleengine/resource_flexibleengine_rds_instance_v3.go
+++ b/flexibleengine/resource_flexibleengine_rds_instance_v3.go
@@ -16,7 +16,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"strings"
 	"time"

--- a/flexibleengine/resource_flexibleengine_rds_read_replica_v3.go
+++ b/flexibleengine/resource_flexibleengine_rds_read_replica_v3.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/flexibleengine/resource_flexibleengine_rts_software_config_v1.go
+++ b/flexibleengine/resource_flexibleengine_rts_software_config_v1.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/flexibleengine/resource_flexibleengine_rts_stack_v1.go
+++ b/flexibleengine/resource_flexibleengine_rts_stack_v1.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"reflect"

--- a/flexibleengine/resource_flexibleengine_s3_bucket.go
+++ b/flexibleengine/resource_flexibleengine_s3_bucket.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/url"
 	"regexp"
 	"strings"

--- a/flexibleengine/resource_flexibleengine_s3_bucket_object.go
+++ b/flexibleengine/resource_flexibleengine_s3_bucket_object.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"sort"
 	"strings"

--- a/flexibleengine/resource_flexibleengine_s3_bucket_policy.go
+++ b/flexibleengine/resource_flexibleengine_s3_bucket_policy.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"

--- a/flexibleengine/resource_flexibleengine_sdrs_drill.go
+++ b/flexibleengine/resource_flexibleengine_sdrs_drill.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/flexibleengine/resource_flexibleengine_sdrs_protectedinstance_v1.go
+++ b/flexibleengine/resource_flexibleengine_sdrs_protectedinstance_v1.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/flexibleengine/resource_flexibleengine_sdrs_protectiongroup_v1.go
+++ b/flexibleengine/resource_flexibleengine_sdrs_protectiongroup_v1.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/flexibleengine/resource_flexibleengine_sdrs_replication_attach_v1.go
+++ b/flexibleengine/resource_flexibleengine_sdrs_replication_attach_v1.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"time"
 

--- a/flexibleengine/resource_flexibleengine_sdrs_replication_pair_v1.go
+++ b/flexibleengine/resource_flexibleengine_sdrs_replication_pair_v1.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"time"
 

--- a/flexibleengine/resource_flexibleengine_sfs_access_rule_v2.go
+++ b/flexibleengine/resource_flexibleengine_sfs_access_rule_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"time"
 

--- a/flexibleengine/resource_flexibleengine_sfs_file_system_v2.go
+++ b/flexibleengine/resource_flexibleengine_sfs_file_system_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"time"
 

--- a/flexibleengine/resource_flexibleengine_sfs_turbo.go
+++ b/flexibleengine/resource_flexibleengine_sfs_turbo.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/flexibleengine/resource_flexibleengine_smn_subscription_v2.go
+++ b/flexibleengine/resource_flexibleengine_smn_subscription_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 

--- a/flexibleengine/resource_flexibleengine_smn_topic_v2.go
+++ b/flexibleengine/resource_flexibleengine_smn_topic_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 

--- a/flexibleengine/resource_flexibleengine_vbs_backup_policy_v2.go
+++ b/flexibleengine/resource_flexibleengine_vbs_backup_policy_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/flexibleengine/resource_flexibleengine_vbs_backup_v2.go
+++ b/flexibleengine/resource_flexibleengine_vbs_backup_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/flexibleengine/resource_flexibleengine_vpc_eip_v1.go
+++ b/flexibleengine/resource_flexibleengine_vpc_eip_v1.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/huaweicloud/golangsdk"

--- a/flexibleengine/resource_flexibleengine_vpc_peering_connection_accepter_v2.go
+++ b/flexibleengine/resource_flexibleengine_vpc_peering_connection_accepter_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/errwrap"

--- a/flexibleengine/resource_flexibleengine_vpc_peering_connection_v2.go
+++ b/flexibleengine/resource_flexibleengine_vpc_peering_connection_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/flexibleengine/resource_flexibleengine_vpc_route_v2.go
+++ b/flexibleengine/resource_flexibleengine_vpc_route_v2.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/flexibleengine/resource_flexibleengine_vpc_subnet_v1.go
+++ b/flexibleengine/resource_flexibleengine_vpc_subnet_v1.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/flexibleengine/resource_flexibleengine_vpc_v1.go
+++ b/flexibleengine/resource_flexibleengine_vpc_v1.go
@@ -2,7 +2,7 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/flexibleengine/types.go
+++ b/flexibleengine/types.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"strings"
 

--- a/flexibleengine/utils.go
+++ b/flexibleengine/utils.go
@@ -3,7 +3,7 @@ package flexibleengine
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/vendor/github.com/aws/aws-sdk-go/aws/logger.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/logger.go
@@ -1,7 +1,7 @@
 package aws
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 )
 

--- a/vendor/github.com/golang/protobuf/proto/clone.go
+++ b/vendor/github.com/golang/protobuf/proto/clone.go
@@ -36,7 +36,7 @@ package proto
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"strings"
 )

--- a/vendor/github.com/golang/protobuf/proto/equal.go
+++ b/vendor/github.com/golang/protobuf/proto/equal.go
@@ -35,7 +35,7 @@ package proto
 
 import (
 	"bytes"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"strings"
 )

--- a/vendor/github.com/golang/protobuf/proto/lib.go
+++ b/vendor/github.com/golang/protobuf/proto/lib.go
@@ -224,7 +224,7 @@ To create and play with a Test object:
 	package main
 
 	import (
-		"log"
+		log "github.com/sourcegraph-ce/logrus"
 
 		"github.com/golang/protobuf/proto"
 		pb "./example.pb"
@@ -266,7 +266,7 @@ package proto
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"sort"
 	"strconv"

--- a/vendor/github.com/golang/protobuf/proto/properties.go
+++ b/vendor/github.com/golang/protobuf/proto/properties.go
@@ -37,7 +37,7 @@ package proto
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"sort"
 	"strconv"

--- a/vendor/github.com/golang/protobuf/proto/text.go
+++ b/vendor/github.com/golang/protobuf/proto/text.go
@@ -40,7 +40,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"math"
 	"reflect"
 	"sort"

--- a/vendor/github.com/hashicorp/go-hclog/intlogger.go
+++ b/vendor/github.com/hashicorp/go-hclog/intlogger.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"runtime"
 	"sort"

--- a/vendor/github.com/hashicorp/go-hclog/logger.go
+++ b/vendor/github.com/hashicorp/go-hclog/logger.go
@@ -2,7 +2,7 @@ package hclog
 
 import (
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"strings"
 	"sync"

--- a/vendor/github.com/hashicorp/go-hclog/nulllogger.go
+++ b/vendor/github.com/hashicorp/go-hclog/nulllogger.go
@@ -3,7 +3,7 @@ package hclog
 import (
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 )
 
 // NewNullLogger instantiates a Logger for which all calls

--- a/vendor/github.com/hashicorp/go-plugin/grpc_broker.go
+++ b/vendor/github.com/hashicorp/go-plugin/grpc_broker.go
@@ -5,7 +5,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"sync"
 	"sync/atomic"

--- a/vendor/github.com/hashicorp/go-plugin/mux_broker.go
+++ b/vendor/github.com/hashicorp/go-plugin/mux_broker.go
@@ -3,7 +3,7 @@ package plugin
 import (
 	"encoding/binary"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"sync"
 	"sync/atomic"

--- a/vendor/github.com/hashicorp/go-plugin/rpc_server.go
+++ b/vendor/github.com/hashicorp/go-plugin/rpc_server.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"net/rpc"
 	"sync"

--- a/vendor/github.com/hashicorp/go-plugin/server.go
+++ b/vendor/github.com/hashicorp/go-plugin/server.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"os"
 	"os/signal"

--- a/vendor/github.com/hashicorp/go-plugin/stream.go
+++ b/vendor/github.com/hashicorp/go-plugin/stream.go
@@ -2,7 +2,7 @@ package plugin
 
 import (
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 )
 
 func copyStream(name string, dst io.Writer, src io.Reader) {

--- a/vendor/github.com/hashicorp/logutils/level.go
+++ b/vendor/github.com/hashicorp/logutils/level.go
@@ -51,7 +51,7 @@ func (f *LevelFilter) Check(line []byte) bool {
 
 func (f *LevelFilter) Write(p []byte) (n int, err error) {
 	// Note in general that io.Writer can receive any byte sequence
-	// to write, but the "log" package always guarantees that we only
+	// to write, but the log "github.com/sourcegraph-ce/logrus" package always guarantees that we only
 	// get a single line. We use that as a slight optimization within
 	// this method, assuming we're dealing with a single, complete line
 	// of log data.

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/logging/logging.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/logging/logging.go
@@ -3,7 +3,7 @@ package logging
 import (
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"strings"
 	"syscall"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/logging/transport.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/logging/transport.go
@@ -3,7 +3,7 @@ package logging
 import (
 	"bytes"
 	"encoding/json"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"net/http/httputil"
 	"strings"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/mutexkv/mutexkv.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/mutexkv/mutexkv.go
@@ -1,7 +1,7 @@
 package mutexkv
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 )
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/resource/state.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/resource/state.go
@@ -1,7 +1,7 @@
 package resource
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 )
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/resource/testing.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/resource/testing.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 	"reflect"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/resource/testing_config.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/resource/testing_config.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sort"
 	"strings"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/resource/testing_import_state.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/resource/testing_import_state.go
@@ -2,7 +2,7 @@ package resource
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"strings"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/schema/field_reader_config.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/schema/field_reader_config.go
@@ -2,7 +2,7 @@ package schema
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 	"strings"
 	"sync"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/schema/resource.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/schema/resource.go
@@ -3,7 +3,7 @@ package schema
 import (
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/schema/resource_data.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/schema/resource_data.go
@@ -1,7 +1,7 @@
 package schema
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"strings"
 	"sync"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/schema/resource_timeout.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/schema/resource_timeout.go
@@ -2,7 +2,7 @@ package schema
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/hcl2shim"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/httpclient/useragent.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/httpclient/useragent.go
@@ -2,7 +2,7 @@ package httpclient
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"strings"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/command/format/plan.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/command/format/plan.go
@@ -3,7 +3,7 @@ package format
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sort"
 	"strings"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/dag/marshal.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/dag/marshal.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"sort"
 	"strconv"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/dag/walk.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/dag/walk.go
@@ -2,7 +2,7 @@ package dag
 
 import (
 	"errors"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 	"time"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/helper/plugin/grpc_provider.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/helper/plugin/grpc_provider.go
@@ -3,7 +3,7 @@ package plugin
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 
 	"github.com/zclconf/go-cty/cty"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/httpclient/client.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/httpclient/client.go
@@ -2,7 +2,7 @@ package httpclient
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"os"
 	"strings"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/initwd/from_module.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/initwd/from_module.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/earlyconfig"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 	"sort"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/initwd/getter.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/initwd/getter.go
@@ -2,7 +2,7 @@ package initwd
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 	"strings"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/initwd/module_install.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/initwd/module_install.go
@@ -2,7 +2,7 @@ package initwd
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 	"strings"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/lang/eval.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/lang/eval.go
@@ -2,7 +2,7 @@ package lang
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 
 	"github.com/hashicorp/hcl2/ext/dynblock"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/lang/funcs/encoding.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/lang/funcs/encoding.go
@@ -5,7 +5,7 @@ import (
 	"compress/gzip"
 	"encoding/base64"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/url"
 	"unicode/utf8"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/lang/functions.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/lang/functions.go
@@ -74,7 +74,7 @@ func (s *Scope) Functions() map[string]function.Function {
 			"keys":             funcs.KeysFunc,
 			"length":           funcs.LengthFunc,
 			"list":             funcs.ListFunc,
-			"log":              funcs.LogFunc,
+			log "github.com/sourcegraph-ce/logrus":              funcs.LogFunc,
 			"lookup":           funcs.LookupFunc,
 			"lower":            stdlib.LowerFunc,
 			"map":              funcs.MapFunc,

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/modsdir/manifest.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/modsdir/manifest.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/plugin/discovery/find.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/plugin/discovery/find.go
@@ -2,7 +2,7 @@ package discovery
 
 import (
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 	"strings"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/plugin/discovery/get.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/plugin/discovery/get.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"os"
 	"path/filepath"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/registry/client.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/registry/client.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"net/url"
 	"path"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/states/statefile/version1_upgrade.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/states/statefile/version1_upgrade.go
@@ -2,7 +2,7 @@ package statefile
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/mitchellh/copystructure"
 )

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/states/statefile/version2_upgrade.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/states/statefile/version2_upgrade.go
@@ -2,7 +2,7 @@ package statefile
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"sort"
 	"strconv"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/states/sync.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/states/sync.go
@@ -1,7 +1,7 @@
 package states
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/svchost/disco/disco.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/svchost/disco/disco.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"mime"
 	"net/http"
 	"net/url"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/svchost/disco/host.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/svchost/disco/host.go
@@ -3,7 +3,7 @@ package disco
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"net/url"
 	"os"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/plugin/grpc_provider.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/plugin/grpc_provider.go
@@ -3,7 +3,7 @@ package plugin
 import (
 	"context"
 	"errors"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 
 	"github.com/zclconf/go-cty/cty"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/plugin/grpc_provisioner.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/plugin/grpc_provisioner.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 
 	plugin "github.com/hashicorp/go-plugin"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/context.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/context.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/context_input.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/context_input.go
@@ -3,7 +3,7 @@ package terraform
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sort"
 
 	"github.com/hashicorp/hcl2/hcl"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/diff.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/diff.go
@@ -4,7 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"regexp"
 	"sort"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/tfdiags"
 )

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_apply.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_apply.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_context_builtin.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_context_builtin.go
@@ -3,7 +3,7 @@ package terraform
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/plans"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_count.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_count.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/hcl2/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_count_boundary.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_count_boundary.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_diff.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_diff.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/hcl2/hcl"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_import_state.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_import_state.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/providers"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_lang.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_lang.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_output.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_output.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/hcl2/hcl"
 	"github.com/zclconf/go-cty/cty"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_provider.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_provider.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/hcl2/hcl"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_read_data.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_read_data.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/zclconf/go-cty/cty"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_refresh.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_refresh.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/zclconf/go-cty/cty"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_state.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_state.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_state_upgrade.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_state_upgrade.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/configschema"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_validate.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_validate.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/hcl2/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_variable.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_variable.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/hcl2/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/evaluate.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/evaluate.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 	"strconv"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/graph.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/graph.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/tfdiags"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/graph_builder.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/graph_builder.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/tfdiags"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/graph_builder_refresh.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/graph_builder_refresh.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/states"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/tfdiags"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/graph_walk_context.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/graph_walk_context.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"context"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 
 	"github.com/zclconf/go-cty/cty"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/node_resource_abstract.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/node_resource_abstract.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sort"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/node_resource_apply.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/node_resource_apply.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/dag"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/node_resource_destroy.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/node_resource_destroy.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/plans"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/providers"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/node_resource_plan.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/node_resource_plan.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/dag"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/tfdiags"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/node_resource_refresh.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/node_resource_refresh.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/plans"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/providers"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/schemas.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/schemas.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/state.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/state.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"reflect"
 	"sort"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/state_upgrade_v2_to_v3.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/state_upgrade_v2_to_v3.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"sort"
 	"strconv"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/dag"
 )

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_attach_config_resource.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_attach_config_resource.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/dag"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_attach_schema.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_attach_schema.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/configschema"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/dag"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_attach_state.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_attach_state.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/dag"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/states"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_config.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_config.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_destroy_cbd.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_destroy_cbd.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/dag"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_destroy_edge.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_destroy_edge.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/states"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_diff.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_diff.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/dag"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/plans"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_expand.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_expand.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/dag"
 )

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_orphan_count.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_orphan_count.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/dag"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_orphan_output.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_orphan_output.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_orphan_resource.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_orphan_resource.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/dag"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_output.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_output.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/dag"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_provider.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_provider.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/hcl2/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_provisioner.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_provisioner.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_reference.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_reference.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/hcl2/hcl"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_removed_modules.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_removed_modules.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/states"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_state.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_state.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/states"
 )

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_targets.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_targets.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/dag"

--- a/vendor/github.com/hashicorp/yamux/mux.go
+++ b/vendor/github.com/hashicorp/yamux/mux.go
@@ -3,7 +3,7 @@ package yamux
 import (
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"time"
 )

--- a/vendor/github.com/hashicorp/yamux/session.go
+++ b/vendor/github.com/hashicorp/yamux/session.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"math"
 	"net"
 	"strings"

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/configurations/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/configurations/requests.go
@@ -2,7 +2,7 @@ package configurations
 
 import (
 	"encoding/base64"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/huaweicloud/golangsdk"
 	"github.com/huaweicloud/golangsdk/pagination"

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/groups/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/groups/urls.go
@@ -1,7 +1,7 @@
 package groups
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/huaweicloud/golangsdk"
 )

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/cloudeyeservice/alarmrule/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/cloudeyeservice/alarmrule/requests.go
@@ -1,7 +1,7 @@
 package alarmrule
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/huaweicloud/golangsdk"
 )

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/dws/cluster/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/dws/cluster/requests.go
@@ -1,7 +1,7 @@
 package cluster
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/huaweicloud/golangsdk"
 )

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/ecs/v1/auto_recovery/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/ecs/v1/auto_recovery/requests.go
@@ -1,7 +1,7 @@
 package auto_recovery
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/huaweicloud/golangsdk"
 )

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/mrs/v1/cluster/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/mrs/v1/cluster/requests.go
@@ -1,7 +1,7 @@
 package cluster
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/huaweicloud/golangsdk"
 )

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/mrs/v1/job/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/mrs/v1/job/requests.go
@@ -1,7 +1,7 @@
 package job
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/huaweicloud/golangsdk"
 )

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/obs/const.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/obs/const.go
@@ -271,7 +271,7 @@ var (
 		"js":      "text/javascript",
 		"json":    "application/json",
 		"latex":   "application/x-latex",
-		"log":     "text/plain",
+		log "github.com/sourcegraph-ce/logrus":     "text/plain",
 		"m4a":     "audio/mp4",
 		"m4v":     "video/mp4",
 		"mid":     "audio/midi",

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/obs/log.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/obs/log.go
@@ -3,7 +3,7 @@ package obs
 import (
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 	"runtime"

--- a/vendor/github.com/huaweicloud/golangsdk/signer_helper.go
+++ b/vendor/github.com/huaweicloud/golangsdk/signer_helper.go
@@ -8,7 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"net/textproto"
 	"net/url"

--- a/vendor/github.com/mitchellh/cli/help.go
+++ b/vendor/github.com/mitchellh/cli/help.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sort"
 	"strings"
 )

--- a/vendor/github.com/mitchellh/go-testing-interface/testing.go
+++ b/vendor/github.com/mitchellh/go-testing-interface/testing.go
@@ -4,7 +4,7 @@ package testing
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 )
 
 // T is the interface that mimics the standard library *testing.T.

--- a/vendor/github.com/mitchellh/go-testing-interface/testing_go19.go
+++ b/vendor/github.com/mitchellh/go-testing-interface/testing_go19.go
@@ -9,7 +9,7 @@ package testing
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 )
 
 // T is the interface that mimics the standard library *testing.T.

--- a/vendor/github.com/posener/complete/log.go
+++ b/vendor/github.com/posener/complete/log.go
@@ -2,7 +2,7 @@ package complete
 
 import (
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 )
 

--- a/vendor/github.com/spf13/afero/memmap.go
+++ b/vendor/github.com/spf13/afero/memmap.go
@@ -15,7 +15,7 @@ package afero
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 	"strings"

--- a/vendor/golang.org/x/crypto/ssh/channel.go
+++ b/vendor/golang.org/x/crypto/ssh/channel.go
@@ -9,7 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 )
 

--- a/vendor/golang.org/x/crypto/ssh/handshake.go
+++ b/vendor/golang.org/x/crypto/ssh/handshake.go
@@ -9,7 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"sync"
 )

--- a/vendor/golang.org/x/crypto/ssh/mux.go
+++ b/vendor/golang.org/x/crypto/ssh/mux.go
@@ -8,7 +8,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 	"sync/atomic"
 )

--- a/vendor/golang.org/x/crypto/ssh/transport.go
+++ b/vendor/golang.org/x/crypto/ssh/transport.go
@@ -9,7 +9,7 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 )
 
 // debugTransport if set, will print packet types as they go over the

--- a/vendor/golang.org/x/net/http2/frame.go
+++ b/vendor/golang.org/x/net/http2/frame.go
@@ -10,7 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"sync"
 

--- a/vendor/golang.org/x/net/http2/server.go
+++ b/vendor/golang.org/x/net/http2/server.go
@@ -33,7 +33,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"math"
 	"net"
 	"net/http"

--- a/vendor/golang.org/x/net/http2/transport.go
+++ b/vendor/golang.org/x/net/http2/transport.go
@@ -17,7 +17,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"math"
 	mathrand "math/rand"
 	"net"

--- a/vendor/golang.org/x/net/http2/write.go
+++ b/vendor/golang.org/x/net/http2/write.go
@@ -7,7 +7,7 @@ package http2
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"net/url"
 

--- a/vendor/golang.org/x/net/internal/timeseries/timeseries.go
+++ b/vendor/golang.org/x/net/internal/timeseries/timeseries.go
@@ -7,7 +7,7 @@ package timeseries // import "golang.org/x/net/internal/timeseries"
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 )
 

--- a/vendor/golang.org/x/net/trace/events.go
+++ b/vendor/golang.org/x/net/trace/events.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"html/template"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"runtime"
 	"sort"

--- a/vendor/golang.org/x/net/trace/histogram.go
+++ b/vendor/golang.org/x/net/trace/histogram.go
@@ -10,7 +10,7 @@ import (
 	"bytes"
 	"fmt"
 	"html/template"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"math"
 	"sync"
 

--- a/vendor/golang.org/x/net/trace/trace.go
+++ b/vendor/golang.org/x/net/trace/trace.go
@@ -68,7 +68,7 @@ import (
 	"fmt"
 	"html/template"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"net/http"
 	"net/url"

--- a/vendor/golang.org/x/oauth2/google/appengine_gen2_flex.go
+++ b/vendor/golang.org/x/oauth2/google/appengine_gen2_flex.go
@@ -10,7 +10,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 
 	"golang.org/x/oauth2"

--- a/vendor/golang.org/x/text/unicode/bidi/core.go
+++ b/vendor/golang.org/x/text/unicode/bidi/core.go
@@ -4,7 +4,7 @@
 
 package bidi
 
-import "log"
+import log "github.com/sourcegraph-ce/logrus"
 
 // This implementation is a port based on the reference implementation found at:
 // https://www.unicode.org/Public/PROGRAMS/BidiReferenceJava/

--- a/vendor/google.golang.org/appengine/internal/api.go
+++ b/vendor/google.golang.org/appengine/internal/api.go
@@ -11,7 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"net/http"
 	"net/url"

--- a/vendor/google.golang.org/appengine/internal/identity_vm.go
+++ b/vendor/google.golang.org/appengine/internal/identity_vm.go
@@ -7,7 +7,7 @@
 package internal
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"os"
 	"strings"

--- a/vendor/google.golang.org/appengine/internal/main_vm.go
+++ b/vendor/google.golang.org/appengine/internal/main_vm.go
@@ -8,7 +8,7 @@ package internal
 
 import (
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"net/url"
 	"os"

--- a/vendor/google.golang.org/appengine/internal/net.go
+++ b/vendor/google.golang.org/appengine/internal/net.go
@@ -8,7 +8,7 @@ package internal
 // It is only used for API calls.
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"runtime"
 	"sync"

--- a/vendor/google.golang.org/grpc/grpclog/loggerv2.go
+++ b/vendor/google.golang.org/grpc/grpclog/loggerv2.go
@@ -21,7 +21,7 @@ package grpclog
 import (
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"strconv"
 )


### PR DESCRIPTION
Namespace(repository='github.com/sourcegraph-ce/terraform-provider-flexibleengine', batch_change_name='log-provider-go-with-python-script', description='This batch change opens a PR for each .go file in a terraform provider repository, and replaces the standard library "log" import statement with the "logrus" library.  This batch change for each repository where the import "log" statement is replaced with "logrus".\n', secret='supersecret', reopen=False)

[_Created by Sourcegraph batch change `admin/log-provider-go-with-python-script`._](https://gcp.s0urcegraph.com/users/admin/batch-changes/log-provider-go-with-python-script)